### PR TITLE
WIP: Generate server API stubs

### DIFF
--- a/src/SwaggerProvider.DesignTime/HandlerCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/HandlerCompiler.fs
@@ -85,7 +85,7 @@ type HandlerCompiler (schema:SwaggerObject, defCompiler:DefinitionCompiler, igno
         let m = ProvidedMethod(methodName, handlerParameter, typeof<unit>, invokeCode = fun args ->
             let thisTy = typeof<ProvidedSwaggerApiBaseType>
             let this = Expr.Coerce(args.[0], thisTy) |> Expr.Cast<ProvidedSwaggerApiBaseType>
-            let httpMethod = Expr.Value (HttpMethod(op.Type.ToString().ToUpper()))
+            let httpMethod = Expr.Value (op.Type.ToString().ToUpper())
             let path = Expr.Value op.Path
             // TODO: augment handler to accept HttpRequestMessage.
             // TODO: retrieve expected parameters from HttpRequestMessage and pass to parameterized handler.

--- a/src/SwaggerProvider.DesignTime/HandlerCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/HandlerCompiler.fs
@@ -2,80 +2,152 @@
 
 open ProviderImplementation.ProvidedTypes
 open FSharp.Data.Runtime.NameUtils
-open SwaggerProvider.Internal
-open SwaggerProvider.Internal.Schema
+open Swagger.Parser.Schema
+open Swagger.Internal
 
 open System
-open System.Collections.Generic
-open System.Threading.Tasks
-open FSharp.Data
 
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Quotations.ExprShape
 open System.Text.RegularExpressions
+open SwaggerProvider.Internal
+open System.Net.Http
+open System.Collections.Generic
 
 /// Object for compiling operations.
-type HandlerCompiler (schema:SwaggerObject, defCompiler:DefinitionCompiler) =
+type HandlerCompiler (schema:SwaggerObject, defCompiler:DefinitionCompiler, ignoreControllerPrefix, ignoreOperationId, asAsync: bool) =
     let compileHandler (methodName:string) (op:OperationObject) =
         if String.IsNullOrWhiteSpace methodName
             then failwithf "Operation name could not be empty. See '%s/%A'" op.Path op.Type
 
-        // TODO: provide op-specific signature using specified parameters
-        let handlerTy = typeof<Func<IDictionary<string, obj>, Task>>
         let parameters =
+            /// handles deduping Swagger parameter names if the same parameter name 
+            /// appears in multiple locations in a given operation definition.
+            let uniqueParamName existing (current: ParameterObject) = 
+                let name = niceCamelName current.Name
+                if Set.contains name existing 
+                then
+                    Set.add current.UnambiguousName existing, current.UnambiguousName
+                else
+                    Set.add name existing, name
+
+            let required, optional = op.Parameters |> Array.partition (fun x->x.Required)
+
+            Array.append required optional
+            |> Array.fold (fun (names,parameters) current ->
+               let (names, paramName) = uniqueParamName names current
+               let paramType = defCompiler.CompileTy methodName paramName current.Type current.Required
+               let providedParam =
+                   if current.Required then ProvidedParameter(paramName, paramType)
+                   else
+                       let paramDefaultValue = defCompiler.GetDefaultValue paramType
+                       ProvidedParameter(paramName, paramType, false, paramDefaultValue)
+               (names, providedParam :: parameters)
+            ) (Set.empty, [])
+            |> snd
+            // because we built up our list in reverse order with the fold, 
+            // reverse it again so that all required properties come first
+            |> List.rev
+
+        // find the innner type value
+        let retTy =
+            let okResponse = // BUG : wrong selector
+                op.Responses |> Array.tryFind (fun (code, _) ->
+                    (code.IsSome && (code.Value = 200 || code.Value = 201)) || code.IsNone)
+            match okResponse with
+            | Some (_,resp) ->
+                match resp.Schema with
+                | None -> None
+                | Some ty -> Some <| defCompiler.CompileTy methodName "Response" ty true
+            | None -> None
+
+        let overallReturnType =
+            ProvidedTypeBuilder.MakeGenericType(
+                (if asAsync 
+                 then typedefof<Async<unit>> 
+                 else typedefof<System.Threading.Tasks.Task<unit>>),
+                [defaultArg retTy (typeof<HttpResponseMessage>)]
+            )
+
+        // TODO: provide op-specific signature using specified parameters
+        let handlerTy =
             (*
-                TODO: create parameterized OWIN handler using specified parameters
-                TODO: generate handler function type that returns expected result type
-            // Generate handler function signature,
-            // e.g. (fun (p1, p2, ..., pn) -> resultType)
-            [let required, optional = op.Parameters |> Array.partition (fun x->x.Required)
-             for x in Array.append required optional do
-                let paramName = niceCamelName x.Name
-                yield ProvidedParameter(paramName, defCompiler.CompileTy methodName paramName x.Type x.Required)
-             // Provide the raw OWIN dictionary in case it's required for additional lookups.
-             yield ProvidedParameter("env", typeof<Option<IDictionary<string, obj>>>)
-            ]
+            ProvidedTypeBuilder.MakeGenericType(
+                typedefof<System.Func<unit, unit>>,
+                // TODO: provide generated parameter(s)
+                [typeof<HttpRequestMessage>; overallReturnType]
+            )
             *)
+            typeof<Func<HttpRequestMessage, Threading.Tasks.Task<HttpResponseMessage>>>
+        let handlerParameter =
             [ProvidedParameter("handler", handlerTy)]
-        
-        let m = ProvidedMethod(methodName, parameters, typeof<unit>)
+
+        let m = ProvidedMethod(methodName, handlerParameter, typeof<unit>, invokeCode = fun args ->
+            let thisTy = typeof<ProvidedSwaggerApiBaseType>
+            let this = Expr.Coerce(args.[0], thisTy) |> Expr.Cast<ProvidedSwaggerApiBaseType>
+            let httpMethod = Expr.Value (HttpMethod(op.Type.ToString().ToUpper()))
+            let path = Expr.Value op.Path
+            // TODO: augment handler to accept HttpRequestMessage.
+            // TODO: retrieve expected parameters from HttpRequestMessage and pass to parameterized handler.
+            // TODO: map result of handler function to the returned HttpResponseMessage.
+            let handler = Expr.Coerce(args.[1], handlerTy)
+            Expr.Call(this, thisTy.GetMethod("AddRoute", Reflection.BindingFlags.Instance ||| Reflection.BindingFlags.Public), [httpMethod; path; handler])
+        )
+
         if not <| String.IsNullOrEmpty(op.Summary)
             then m.AddXmlDoc(op.Summary) // TODO: Use description of parameters in docs
         if op.Deprecated
             then m.AddObsoleteAttribute("Operation is deprecated", false)
-
-        // Whenver the method is invoked, it should register/update a route with the specified handler.
-        m.InvokeCode <- fun args ->
-            let thisTy = typeof<SwaggerProvider.Internal.ProvidedSwaggerApiBaseType>
-            let this = Expr.Coerce(args.[0], thisTy)
-            let httpMethod = Expr.Value (op.Type.ToString().ToUpper())
-            let path = Expr.Value op.Path
-            // TODO: augment handler to accept OWIN environment variable.
-            // TODO: retrieve expected parameters from OWIN environment and pass to parameterized handler.
-            // TODO: write type result of handler function to the "owin.ResponseBody" stream and set appropriate headers.
-            let handler = Expr.Coerce(args.[1], handlerTy)
-            Expr.Call(this, thisTy.GetMethod("AddRoute", Reflection.BindingFlags.Instance ||| Reflection.BindingFlags.Public), [httpMethod; path; handler])
-        
         m
 
-    /// Compiles the operation.
-    member __.CompilePaths(ignoreOperationId) =
-        let methodNameScope = UniqueNameGenerator()
-        let pathToName opType (opPath:String) =
-            String.Join("_",
-                [|
-                    yield opType.ToString()
-                    yield!
-                        opPath.Split('/')
-                        |> Array.filter (fun x ->
-                            not <| (String.IsNullOrEmpty(x) || x.StartsWith("{")))
-                |])
-        let getMethodNameCandidate (op:OperationObject) =
-            if ignoreOperationId || String.IsNullOrWhiteSpace(op.OperationId)
-            then pathToName op.Type op.Path
-            else op.OperationId
+    static member GetMethodNameCandidate (op:OperationObject) skipLength ignoreOperationId =
+        if ignoreOperationId || String.IsNullOrWhiteSpace(op.OperationId)
+        then
+            [|  yield op.Type.ToString()
+                yield!
+                    op.Path.Split('/')
+                    |> Array.filter (fun x ->
+                        not <| (String.IsNullOrEmpty(x) || x.StartsWith("{")))
+            |] |> fun arr -> String.Join("_", arr)
+        else op.OperationId.Substring(skipLength)
+        |> nicePascalName
+
+    member __.CompileProvidedHandlers(ns:NamespaceAbstraction) =
+        let defaultHost =
+            let protocol =
+                match schema.Schemes with
+                | [||]  -> "http" // Should use the scheme used to access the Swagger definition itself.
+                | array -> array.[0]
+            sprintf "%s://%s" protocol schema.Host
+        let baseTy = Some typeof<ProvidedSwaggerBaseType>
+        let baseCtor = baseTy.Value.GetConstructors().[0]
 
         List.ofArray schema.Paths
-        |> List.map (fun op ->
-            let methodNameCandidate = nicePascalName <| getMethodNameCandidate op
-            compileHandler (methodNameScope.MakeUnique methodNameCandidate) op)
+        |> List.groupBy (fun x ->
+            if ignoreControllerPrefix then String.Empty //
+            else
+                let ind = x.OperationId.IndexOf("_")
+                if ind <= 0 then String.Empty
+                else x.OperationId.Substring(0, ind) )
+        |> List.iter (fun (handlerName, operations) ->
+            let tyName = ns.ReserveUniqueName handlerName "Handler"
+            let ty = ProvidedTypeDefinition(tyName, baseTy, isErased = false, hideObjectMethods = true)
+            ns.RegisterType(tyName, ty)
+            ty.AddXmlDoc (sprintf "Handler for '%s_*' operations" handlerName)
+
+            ty.AddMember <|
+                ProvidedConstructor(
+                    [ProvidedParameter("host", typeof<string>, optionalValue = defaultHost)],
+                    invokeCode = (fun args ->
+                        match args with
+                        | [] -> failwith "Generated constructors should always pass the instance as the first argument!"
+                        | _ -> <@@ () @@>),
+                    BaseConstructorCall = fun args -> (baseCtor, args))
+
+            let methodNameScope = UniqueNameGenerator()
+            operations |> List.map (fun op ->
+                let skipLength = if String.IsNullOrEmpty handlerName then 0 else handlerName.Length + 1
+                let name = HandlerCompiler.GetMethodNameCandidate op skipLength ignoreOperationId
+                compileHandler (methodNameScope.MakeUnique name) op)
+            |> ty.AddMembers
+        )

--- a/src/SwaggerProvider.DesignTime/HandlerCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/HandlerCompiler.fs
@@ -1,0 +1,81 @@
+﻿namespace SwaggerProvider.Internal.Compilers
+
+open ProviderImplementation.ProvidedTypes
+open FSharp.Data.Runtime.NameUtils
+open SwaggerProvider.Internal
+open SwaggerProvider.Internal.Schema
+
+open System
+open System.Collections.Generic
+open System.Threading.Tasks
+open FSharp.Data
+
+open Microsoft.FSharp.Quotations
+open Microsoft.FSharp.Quotations.ExprShape
+open System.Text.RegularExpressions
+
+/// Object for compiling operations.
+type HandlerCompiler (schema:SwaggerObject, defCompiler:DefinitionCompiler) =
+    let compileHandler (methodName:string) (op:OperationObject) =
+        if String.IsNullOrWhiteSpace methodName
+            then failwithf "Operation name could not be empty. See '%s/%A'" op.Path op.Type
+
+        // TODO: provide op-specific signature using specified parameters
+        let handlerTy = typeof<Func<IDictionary<string, obj>, Task>>
+        let parameters =
+            (*
+                TODO: create parameterized OWIN handler using specified parameters
+                TODO: generate handler function type that returns expected result type
+            // Generate handler function signature,
+            // e.g. (fun (p1, p2, ..., pn) -> resultType)
+            [let required, optional = op.Parameters |> Array.partition (fun x->x.Required)
+             for x in Array.append required optional do
+                let paramName = niceCamelName x.Name
+                yield ProvidedParameter(paramName, defCompiler.CompileTy methodName paramName x.Type x.Required)
+             // Provide the raw OWIN dictionary in case it's required for additional lookups.
+             yield ProvidedParameter("env", typeof<Option<IDictionary<string, obj>>>)
+            ]
+            *)
+            [ProvidedParameter("handler", handlerTy)]
+        
+        let m = ProvidedMethod(methodName, parameters, typeof<unit>)
+        if not <| String.IsNullOrEmpty(op.Summary)
+            then m.AddXmlDoc(op.Summary) // TODO: Use description of parameters in docs
+        if op.Deprecated
+            then m.AddObsoleteAttribute("Operation is deprecated", false)
+
+        // Whenver the method is invoked, it should register/update a route with the specified handler.
+        m.InvokeCode <- fun args ->
+            let thisTy = typeof<SwaggerProvider.Internal.ProvidedSwaggerApiBaseType>
+            let this = Expr.Coerce(args.[0], thisTy)
+            let httpMethod = Expr.Value (op.Type.ToString().ToUpper())
+            let path = Expr.Value op.Path
+            // TODO: augment handler to accept OWIN environment variable.
+            // TODO: retrieve expected parameters from OWIN environment and pass to parameterized handler.
+            // TODO: write type result of handler function to the "owin.ResponseBody" stream and set appropriate headers.
+            let handler = Expr.Coerce(args.[1], handlerTy)
+            Expr.Call(this, thisTy.GetMethod("AddRoute", Reflection.BindingFlags.Instance ||| Reflection.BindingFlags.Public), [httpMethod; path; handler])
+        
+        m
+
+    /// Compiles the operation.
+    member __.CompilePaths(ignoreOperationId) =
+        let methodNameScope = UniqueNameGenerator()
+        let pathToName opType (opPath:String) =
+            String.Join("_",
+                [|
+                    yield opType.ToString()
+                    yield!
+                        opPath.Split('/')
+                        |> Array.filter (fun x ->
+                            not <| (String.IsNullOrEmpty(x) || x.StartsWith("{")))
+                |])
+        let getMethodNameCandidate (op:OperationObject) =
+            if ignoreOperationId || String.IsNullOrWhiteSpace(op.OperationId)
+            then pathToName op.Type op.Path
+            else op.OperationId
+
+        List.ofArray schema.Paths
+        |> List.map (fun op ->
+            let methodNameCandidate = nicePascalName <| getMethodNameCandidate op
+            compileHandler (methodNameScope.MakeUnique methodNameCandidate) op)

--- a/src/SwaggerProvider.DesignTime/HandlerCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/HandlerCompiler.fs
@@ -119,6 +119,7 @@ type HandlerCompiler (schema:SwaggerObject, defCompiler:DefinitionCompiler, igno
                 | [||]  -> "http" // Should use the scheme used to access the Swagger definition itself.
                 | array -> array.[0]
             sprintf "%s://%s" protocol schema.Host
+        let defaultBasePath = schema.BasePath
         let baseTy = Some typeof<ProvidedSwaggerApiBaseType>
         let baseCtor = baseTy.Value.GetConstructors().[0]
 
@@ -137,7 +138,8 @@ type HandlerCompiler (schema:SwaggerObject, defCompiler:DefinitionCompiler, igno
 
             ty.AddMember <|
                 ProvidedConstructor(
-                    [ProvidedParameter("host", typeof<string>, optionalValue = defaultHost)],
+                    [ProvidedParameter("host", typeof<string>, optionalValue = defaultHost)
+                     ProvidedParameter("basePath", typeof<string>, optionalValue = defaultBasePath)],
                     invokeCode = (fun args ->
                         match args with
                         | [] -> failwith "Generated constructors should always pass the instance as the first argument!"

--- a/src/SwaggerProvider.DesignTime/SwaggerApiProvider.fs
+++ b/src/SwaggerProvider.DesignTime/SwaggerApiProvider.fs
@@ -3,12 +3,11 @@
 open System
 open ProviderImplementation.ProvidedTypes
 open Microsoft.FSharp.Core.CompilerServices
-open FSharp.Configuration.Helper
 
 /// The Swagger Type Provider.
 [<TypeProvider>]
 type public SwaggerApiTypeProvider(cfg : TypeProviderConfig) as this =
-    inherit TypeProviderForNamespaces()
+    inherit TypeProviderForNamespaces(cfg)
 
     static do
       // When SwaggerProvider is installed via NuGet/Paket, the Newtonsoft.Json assembly and
@@ -18,9 +17,9 @@ type public SwaggerApiTypeProvider(cfg : TypeProviderConfig) as this =
       AppDomain.CurrentDomain.add_AssemblyResolve(fun source args ->
         SwaggerProvider.Internal.Configuration.resolveReferencedAssembly args.Name)
 
-    let context = new Context(this, cfg)
     do
         this.RegisterRuntimeAssemblyLocationAsProbingFolder cfg
+
         this.AddNamespace(
             SwaggerApiProviderConfig.NameSpace,
-            [SwaggerApiProviderConfig.typedSwaggerApiProvider context cfg.RuntimeAssembly])
+            [SwaggerApiProviderConfig.typedSwaggerApiProvider this.TargetContext cfg.RuntimeAssembly])

--- a/src/SwaggerProvider.DesignTime/SwaggerApiProvider.fs
+++ b/src/SwaggerProvider.DesignTime/SwaggerApiProvider.fs
@@ -1,0 +1,26 @@
+﻿namespace SwaggerProvider
+
+open System
+open ProviderImplementation.ProvidedTypes
+open Microsoft.FSharp.Core.CompilerServices
+open FSharp.Configuration.Helper
+
+/// The Swagger Type Provider.
+[<TypeProvider>]
+type public SwaggerApiTypeProvider(cfg : TypeProviderConfig) as this =
+    inherit TypeProviderForNamespaces()
+
+    static do
+      // When SwaggerProvider is installed via NuGet/Paket, the Newtonsoft.Json assembly and
+      // will appear typically in "../../*/lib/net40". To support this, we look at
+      // SwaggerProvider.dll.config which has this pattern in custom key "ProbingLocations".
+      // Here, we resolve assemblies by looking into the specified search paths.
+      AppDomain.CurrentDomain.add_AssemblyResolve(fun source args ->
+        SwaggerProvider.Internal.Configuration.resolveReferencedAssembly args.Name)
+
+    let context = new Context(this, cfg)
+    do
+        this.RegisterRuntimeAssemblyLocationAsProbingFolder cfg
+        this.AddNamespace(
+            SwaggerApiProviderConfig.NameSpace,
+            [SwaggerApiProviderConfig.typedSwaggerApiProvider context cfg.RuntimeAssembly])

--- a/src/SwaggerProvider.DesignTime/SwaggerApiProviderConfig.fs
+++ b/src/SwaggerProvider.DesignTime/SwaggerApiProviderConfig.fs
@@ -1,0 +1,105 @@
+﻿namespace SwaggerProvider
+
+open System.Reflection
+open ProviderImplementation.ProvidedTypes
+open Microsoft.FSharp.Core.CompilerServices
+open Microsoft.FSharp.Quotations
+open System
+open System.Runtime.Caching
+open FSharp.Data
+open FSharp.Configuration.Helper
+open SwaggerProvider.Internal.Schema
+open SwaggerProvider.Internal.Schema.Parsers
+open SwaggerProvider.Internal.Compilers
+
+module private SwaggerApiProviderConfig =
+    let NameSpace = "SwaggerProvider"
+
+    let internal typedSwaggerApiProvider (context: Context) runtimeAssemlby =
+        let asm = Assembly.LoadFrom runtimeAssemlby
+
+        let swaggerApiProvider = ProvidedTypeDefinition(asm, NameSpace, "SwaggerApiProvider", Some typeof<obj>, IsErased = false)
+
+        let staticParams =
+            [ ProvidedStaticParameter("Schema", typeof<string>)
+              ProvidedStaticParameter("Headers", typeof<string>,"")
+              ProvidedStaticParameter("IgnoreOperationId", typeof<bool>, false)]
+
+        //TODO: Add use operationID flag
+        swaggerApiProvider.AddXmlDoc
+            """<summary>Statically typed Swagger API provider.</summary>
+               <param name='Schema'>Url or Path to Swagger schema file.</param>
+               <param name='Headers'>Headers that will be used to access the schema.</param>
+               <param name='IgnoreOperationId'>IgnoreOperationId tells SwaggerApiProvider not to use `operationsId` and generate method names using `path` only. Default value `false`</param>"""
+
+        let cache = new MemoryCache("SwaggerApiProvider")
+        context.AddDisposable cache
+
+        swaggerApiProvider.DefineStaticParameters(
+                parameters=staticParams,
+                instantiationFunction = (fun typeName args ->
+                    let value = lazy (
+                        let schemaPathRaw = args.[0] :?> string
+                        let ignoreOperationId = args.[2] :?> bool
+
+                        let schemaData =
+                            match schemaPathRaw.StartsWith("http", true, null) with
+                            | true  ->
+                                let headersStr = args.[1] :?> string
+                                let headers =
+                                    headersStr.Split('|')
+                                    |> Seq.choose (fun x ->
+                                        let pair = x.Split('=')
+                                        if (pair.Length = 2)
+                                        then Some (pair.[0],pair.[1])
+                                        else None
+                                    )
+                                Http.RequestString(schemaPathRaw, headers=headers,
+                                    customizeHttpRequest = fun req ->
+                                        req.Credentials <- System.Net.CredentialCache.DefaultNetworkCredentials
+                                        req)
+                            | false ->
+                                context.WatchFile schemaPathRaw
+                                schemaPathRaw |> IO.File.ReadAllText
+
+                        let schema =
+                            if schemaData.Trim().StartsWith("{")
+                            then JsonValue.Parse  schemaData |> JsonNodeAdapter |> Parser.parseSwaggerObject
+                            else YamlParser.Parse schemaData |> YamlNodeAdapter |> Parser.parseSwaggerObject
+
+                        // Create Swagger provider type
+                        let baseTy = Some typeof<SwaggerProvider.Internal.ProvidedSwaggerApiBaseType>
+                        let ty = ProvidedTypeDefinition(asm, NameSpace, typeName, baseTy, IsErased = false)
+                        ty.AddXmlDoc ("Swagger.io Provider for " + schema.Host)
+                        ty.HideObjectMethods <- true
+
+                        let protocol =
+                            match schema.Schemes with
+                            | [||]  -> "http" // Should use the scheme used to access the Swagger definition itself.
+                            | array -> array.[0]
+                        let ctor =
+                            ProvidedConstructor([],
+                                InvokeCode = fun args ->
+                                    match args with
+                                    | [] -> failwith "Generated constructors should always pass the instance as the first argument!"
+                                    | _ -> <@@ () @@>)
+                        ctor.BaseConstructorCall <-
+                            let baseCtor = baseTy.Value.GetConstructors().[0]
+                            fun args -> (baseCtor, args)
+                        ty.AddMember ctor
+
+                        let defCompiler = DefinitionCompiler(schema)
+                        let opCompiler = HandlerCompiler(schema, defCompiler)
+                        ty.AddMembers <| opCompiler.CompilePaths(ignoreOperationId) // Add all operations
+                        ty.AddMembers <| defCompiler.GetProvidedTypes() // Add all compiled types
+
+                        let tempAsmPath = System.IO.Path.ChangeExtension(System.IO.Path.GetTempFileName(), ".dll")
+                        let tempAsm = ProvidedAssembly tempAsmPath
+                        tempAsm.AddTypes [ty]
+
+                        ty)
+                    cache.GetOrAdd(typeName, value)
+                ))
+        swaggerApiProvider
+
+

--- a/src/SwaggerProvider.DesignTime/SwaggerApiProviderConfig.fs
+++ b/src/SwaggerProvider.DesignTime/SwaggerApiProviderConfig.fs
@@ -2,104 +2,97 @@
 
 open System.Reflection
 open ProviderImplementation.ProvidedTypes
-open Microsoft.FSharp.Core.CompilerServices
-open Microsoft.FSharp.Quotations
 open System
-open System.Runtime.Caching
-open FSharp.Data
-open FSharp.Configuration.Helper
-open SwaggerProvider.Internal.Schema
-open SwaggerProvider.Internal.Schema.Parsers
+open System.Net.Http
+open Swagger.Parser
 open SwaggerProvider.Internal.Compilers
 
 module private SwaggerApiProviderConfig =
     let NameSpace = "SwaggerProvider"
 
-    let internal typedSwaggerApiProvider (context: Context) runtimeAssemlby =
-        let asm = Assembly.LoadFrom runtimeAssemlby
+    let internal typedSwaggerApiProvider (ctx: ProvidedTypesContext) asmLocation =
+        let asm = Assembly.LoadFrom asmLocation
+        let swaggerApiProvider = ProvidedTypeDefinition(asm, NameSpace, "SwaggerApiProvider", Some typeof<obj>, isErased = false)
 
-        let swaggerApiProvider = ProvidedTypeDefinition(asm, NameSpace, "SwaggerApiProvider", Some typeof<obj>, IsErased = false)
+        let staticParam name ty doc (def: 'a option) =
+            let p =
+                match def with
+                | Some d -> ProvidedStaticParameter(name, ty, d)
+                | None -> ProvidedStaticParameter(name, ty)
+            p.AddXmlDoc(doc)
+            p
 
         let staticParams =
             [ ProvidedStaticParameter("Schema", typeof<string>)
-              ProvidedStaticParameter("Headers", typeof<string>,"")
-              ProvidedStaticParameter("IgnoreOperationId", typeof<bool>, false)]
+              ProvidedStaticParameter("Headers", typeof<string>, "")
+              ProvidedStaticParameter("IgnoreOperationId", typeof<bool>, false)
+              ProvidedStaticParameter("IgnoreControllerPrefix", typeof<bool>, true)
+              ProvidedStaticParameter("ProvideNullable", typeof<bool>, false)
+              ProvidedStaticParameter("PreferAsync", typeof<bool>, false)]
 
         //TODO: Add use operationID flag
         swaggerApiProvider.AddXmlDoc
             """<summary>Statically typed Swagger API provider.</summary>
                <param name='Schema'>Url or Path to Swagger schema file.</param>
                <param name='Headers'>Headers that will be used to access the schema.</param>
-               <param name='IgnoreOperationId'>IgnoreOperationId tells SwaggerApiProvider not to use `operationsId` and generate method names using `path` only. Default value `false`</param>"""
-
-        let cache = new MemoryCache("SwaggerApiProvider")
-        context.AddDisposable cache
+               <param name='IgnoreOperationId'>IgnoreOperationId tells SwaggerProvider not to use `operationsId` and generate method names using `path` only. Default value `false`</param>
+               <param name='IgnoreControllerPrefix'>IgnoreControllerPrefix tells SwaggerProvider not to parse `operationsId` as `<controllerName>_<methodName>` and generate one client class for all operations. Default value `true`</param>
+               <param name='ProvideNullable'>Provide `Nullable<_>` for not required properties, instread of `Option<_>`</param>
+               <param name='PreferAsync'>PreferAsync tells the SwaggerProvider to generate async actions of type `Async<'T>` instead of `Task<'T>`. Defaults to `false`</param>"""
 
         swaggerApiProvider.DefineStaticParameters(
-                parameters=staticParams,
-                instantiationFunction = (fun typeName args ->
-                    let value = lazy (
-                        let schemaPathRaw = args.[0] :?> string
-                        let ignoreOperationId = args.[2] :?> bool
+            parameters=staticParams,
+            instantiationFunction = (fun typeName args ->
+                let tempAsm = ProvidedAssembly()
+                let schemaPathRaw = args.[0] :?> string
+                let ignoreOperationId = args.[2] :?> bool
+                let ignoreControllerPrefix = args.[3] :?> bool
+                let provideNullable = args.[4] :?> bool
+                let asAsync = args.[5] :?> bool
 
-                        let schemaData =
-                            match schemaPathRaw.StartsWith("http", true, null) with
-                            | true  ->
-                                let headersStr = args.[1] :?> string
-                                let headers =
-                                    headersStr.Split('|')
-                                    |> Seq.choose (fun x ->
-                                        let pair = x.Split('=')
-                                        if (pair.Length = 2)
-                                        then Some (pair.[0],pair.[1])
-                                        else None
-                                    )
-                                Http.RequestString(schemaPathRaw, headers=headers,
-                                    customizeHttpRequest = fun req ->
-                                        req.Credentials <- System.Net.CredentialCache.DefaultNetworkCredentials
-                                        req)
-                            | false ->
-                                context.WatchFile schemaPathRaw
-                                schemaPathRaw |> IO.File.ReadAllText
+                let schemaData =
+                    match schemaPathRaw.StartsWith("http", true, null) with
+                    | true  ->
+                        let headersStr = args.[1] :?> string
+                        let headers =
+                            headersStr.Split('|')
+                            |> Seq.choose (fun x ->
+                                let pair = x.Split('=')
+                                if (pair.Length = 2)
+                                then Some (pair.[0],pair.[1])
+                                else None
+                            )
+                        let request = new HttpRequestMessage(HttpMethod.Get, schemaPathRaw)
+                        for (name, value) in headers do 
+                            request.Headers.Add(name, value)
+                        // using a custom handler means that we can set the default credentials.
+                        let handler = new HttpClientHandler(UseDefaultCredentials = true)
+                        let client = new HttpClient(handler)
+                        async {
+                            let! response = client.SendAsync(request) |> Async.AwaitTask
+                            return! response.Content.ReadAsStringAsync() |> Async.AwaitTask
+                        } |> Async.RunSynchronously
+                    | false ->
+                        schemaPathRaw |> IO.File.ReadAllText
 
-                        let schema =
-                            if schemaData.Trim().StartsWith("{")
-                            then JsonValue.Parse  schemaData |> JsonNodeAdapter |> Parser.parseSwaggerObject
-                            else YamlParser.Parse schemaData |> YamlNodeAdapter |> Parser.parseSwaggerObject
+                let schema = SwaggerParser.parseSchema schemaData
 
-                        // Create Swagger provider type
-                        let baseTy = Some typeof<SwaggerProvider.Internal.ProvidedSwaggerApiBaseType>
-                        let ty = ProvidedTypeDefinition(asm, NameSpace, typeName, baseTy, IsErased = false)
-                        ty.AddXmlDoc ("Swagger.io Provider for " + schema.Host)
-                        ty.HideObjectMethods <- true
+                // Create Swagger provider type
+                let baseTy = Some typeof<obj>
+                let ty = ProvidedTypeDefinition(tempAsm, NameSpace, typeName, baseTy, isErased = false)
+                ty.AddXmlDoc ("Swagger API Provider for " + schema.Host)
+                ty.AddMember <| ProvidedConstructor([], invokeCode = fun _ -> <@@ () @@>)
 
-                        let protocol =
-                            match schema.Schemes with
-                            | [||]  -> "http" // Should use the scheme used to access the Swagger definition itself.
-                            | array -> array.[0]
-                        let ctor =
-                            ProvidedConstructor([],
-                                InvokeCode = fun args ->
-                                    match args with
-                                    | [] -> failwith "Generated constructors should always pass the instance as the first argument!"
-                                    | _ -> <@@ () @@>)
-                        ctor.BaseConstructorCall <-
-                            let baseCtor = baseTy.Value.GetConstructors().[0]
-                            fun args -> (baseCtor, args)
-                        ty.AddMember ctor
+                let defCompiler = DefinitionCompiler(schema, provideNullable)
+                let opCompiler = HandlerCompiler(schema, defCompiler, ignoreControllerPrefix, ignoreOperationId, asAsync)
 
-                        let defCompiler = DefinitionCompiler(schema)
-                        let opCompiler = HandlerCompiler(schema, defCompiler)
-                        ty.AddMembers <| opCompiler.CompilePaths(ignoreOperationId) // Add all operations
-                        ty.AddMembers <| defCompiler.GetProvidedTypes() // Add all compiled types
+                opCompiler.CompileProvidedHandlers(defCompiler.Namespace)
+                ty.AddMembers <| defCompiler.Namespace.GetProvidedTypes() // Add all provided types
 
-                        let tempAsmPath = System.IO.Path.ChangeExtension(System.IO.Path.GetTempFileName(), ".dll")
-                        let tempAsm = ProvidedAssembly tempAsmPath
-                        tempAsm.AddTypes [ty]
+                tempAsm.AddTypes [ty]
 
-                        ty)
-                    cache.GetOrAdd(typeName, value)
-                ))
+                ty
+            ))
         swaggerApiProvider
 
 

--- a/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
+++ b/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
@@ -69,9 +69,9 @@
     <Compile Include="Configuration.fs" />
     <Compile Include="SwaggerProviderConfig.fs" />
     <Compile Include="SwaggerProvider.fs" />
-    <None Include="paket.references" />
     <Compile Include="SwaggerApiProviderConfig.fs" />
     <Compile Include="SwaggerApiProvider.fs" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SwaggerProvider.Runtime\SwaggerProvider.Runtime.fsproj">

--- a/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
+++ b/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
@@ -65,10 +65,13 @@
     <Compile Include="Utils.fs" />
     <Compile Include="DefinitionCompiler.fs" />
     <Compile Include="OperationCompiler.fs" />
-    <Compile Include="SwaggerProviderConfig.fs" />
+    <Compile Include="HandlerCompiler.fs" />
     <Compile Include="Configuration.fs" />
+    <Compile Include="SwaggerProviderConfig.fs" />
     <Compile Include="SwaggerProvider.fs" />
     <None Include="paket.references" />
+    <Compile Include="SwaggerApiProviderConfig.fs" />
+    <Compile Include="SwaggerApiProvider.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SwaggerProvider.Runtime\SwaggerProvider.Runtime.fsproj">

--- a/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
+++ b/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
@@ -23,7 +23,7 @@ type ProvidedSwaggerApiBaseType (host:string, basePath:string) =
     member val Host = host with get, set
     member val BasePath = basePath with get, set
 
-    // TODO: make this private or internal
+    // TODO: make this an indexer property
     member __.AddRoute(httpMethod, templatePath, handler) =
         let d = match routes.TryGetValue(templatePath) with
                 | true, d -> d
@@ -41,6 +41,10 @@ type ProvidedSwaggerApiBaseType (host:string, basePath:string) =
             | true, handler -> handler.Invoke(req)
             | false, _ -> ProvidedSwaggerApiBaseType.RespondMethodNotAllowed(req)
         | false, _ -> ProvidedSwaggerApiBaseType.RespondNotFound(req)
+
+    static member internal RespondBadRequest(req:HttpRequestMessage) =
+        let response = new HttpResponseMessage(Net.HttpStatusCode.BadRequest, RequestMessage = req)
+        Task.FromResult(response)
 
     static member internal RespondNotFound(req:HttpRequestMessage) =
         let response = new HttpResponseMessage(Net.HttpStatusCode.NotFound, RequestMessage = req)

--- a/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
+++ b/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
@@ -1,6 +1,8 @@
 ﻿namespace Swagger.Internal
 
 open System
+open System.Collections.Generic
+open System.Threading.Tasks
 open Newtonsoft.Json
 open Swagger.Serialization
 open System.Threading.Tasks

--- a/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
+++ b/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
@@ -1,4 +1,4 @@
-﻿namespace Swagger.Internal
+namespace Swagger.Internal
 
 open System
 open System.Collections.Generic

--- a/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
+++ b/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
@@ -18,18 +18,18 @@ type HttpHandler = Func<HttpRequestMessage, Task<HttpResponseMessage>>
 
 /// Provides an OWIN AppFunc that internally handles routing based on registered routes.
 type ProvidedSwaggerApiBaseType () =
-    let routes = Dictionary<TemplatePath, Dictionary<HttpMethod, HttpHandler>>()
+    let routes = Dictionary<TemplatePath, Dictionary<string, HttpHandler>>(StringComparer.OrdinalIgnoreCase)
 
     // TODO: make this private or internal
     member __.AddRoute(httpMethod, templatePath, handler) =
         let d = match routes.TryGetValue(templatePath) with
                 | true, d -> d
-                | false, _ -> Dictionary<HttpMethod, HttpHandler>()
+                | false, _ -> Dictionary<string, HttpHandler>(StringComparer.OrdinalIgnoreCase)
         d.[httpMethod] <- handler
         routes.[templatePath] <- d
 
     member __.Invoke(req:HttpRequestMessage) =
-        let httpMethod = req.Method
+        let httpMethod = req.Method.Method
         let path = req.RequestUri.AbsolutePath
         // TODO: check parameterized path + query string + headers for a match; possibly use Freya router?
         match routes.TryGetValue(path) with

--- a/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
@@ -1,4 +1,4 @@
-﻿module Swagger.PetStore.Tests
+module Swagger.PetStore.Tests
 
 open SwaggerProvider
 open Expecto

--- a/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
@@ -72,13 +72,14 @@ open System.Net.Http
 open System.Threading.Tasks
 
 type PetStoreServer = SwaggerApiProvider<"http://petstore.swagger.io/v2/swagger.json">
-let server = PetStoreServer.Handler()
+let server =
+    PetStoreServer.Handler(
+        AddPet = fun req ->
+            let response = new HttpResponseMessage(Net.HttpStatusCode.Created, RequestMessage = req)
+            Task.FromResult(response)
+    )
 
 // Define AddPet handler
-server.AddPet(fun req ->
-    let response = new HttpResponseMessage(Net.HttpStatusCode.Created, RequestMessage = req)
-    Task.FromResult(response)
-)
 
 let makeRequest (httpMethod:string) (path:string) (body:byte[] option) =
     let request = new HttpRequestMessage(HttpMethod(httpMethod), server.Host + server.BasePath + path)

--- a/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
@@ -81,7 +81,7 @@ server.AddPet(fun req ->
 )
 
 let makeRequest (httpMethod:string) (path:string) (body:byte[] option) =
-    let request = new HttpRequestMessage(HttpMethod(httpMethod), "http://petstore.swagger.io/v2" + path)
+    let request = new HttpRequestMessage(HttpMethod(httpMethod), server.Host + server.BasePath + path)
     match body with
     | Some bytes -> request.Content <- new ByteArrayContent(bytes)
     | None -> ()


### PR DESCRIPTION
Builds on https://github.com/fsprojects/SwaggerProvider/pull/92

## Goals
- [ ] Generate request input type (include `HttpRequestMessage` property to allow more control)
  - [ ] Correct deserialization based on `Content-Type` (How far should we go? And do we expose the raw body `Stream` for greater control?)
- [ ] Generate response output type (include `ResponseHeaders` property to allow more control)
  - [ ] Correct serialization based on specified return type
  - [ ] Return type hierarchy for multiple return types based on status code (e.g. PUT /pet)
  - [ ] Return type with escape hatch accepting raw `HttpResponseMessage`
- [ ] Support `IgnoreControllerPrefix` (e.g. quasi-controllers registering their routes on a shared `Handler` instance)
- [ ] Switch between `Task`/`Async` based on TP parameter
- [ ] Switch between `Nullable`/`Option` based on TP parameter

## Stretch goals
- [ ] parameter validation
- [ ] security - how? `ClaimsPrincipal` required?
- [ ] content negotiation based on `Accept` headers